### PR TITLE
Remove rounding in CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Three data files are saved in a directory named `data/<participant_id>/`.
     * This file contains one row per trial with key outcome measures and timestamps.
     * Key columns include `trial_number`, `stimulus_temp`, `selected_surface`, `pain_binary_coded` (1 for painful, 0 for non-painful), `vas_final_coded_rating`, and timestamps for each routine.
     * The VAS rating is coded with an offset of 100 for painful trials.
+    * Timestamps are written with full floating point precision, so no rounding is applied in the output CSV.
 
 2.  **VAS Traces (`*_VASTraces_Long.csv`)**
     * This file contains continuous VAS rating data in a long format.

--- a/data_management.py
+++ b/data_management.py
@@ -113,7 +113,7 @@ def save_all_data(exp_info, exp_name, data, this_dir):
             'vas_end_time': data['vas_end_time']
         })
         summary_filename = os.path.join(participant_dir, f"{base_filename}_TrialSummary.csv")
-        summary_df.to_csv(summary_filename, index=False, float_format='%.2f', na_rep='NA')
+        summary_df.to_csv(summary_filename, index=False, na_rep='NA')
         print(f"Trial summary saved to {summary_filename}")
     except Exception as e:
         print(f"ERROR saving summary CSV: {e}")


### PR DESCRIPTION
## Summary
- keep timestamps full precision when saving TrialSummary CSV
- mention timestamp precision in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b3349a54833196532ef55b666aa6