### PR TITLE
Fix runaway VAS cursor

### DIFF
--- a/main_experiment.py
+++ b/main_experiment.py
@@ -382,6 +382,12 @@ for this_trial in main_loop:
     kb.clearEvents()
     event.clearEvents(eventType="keyboard")
 
+    # Ensure no movement keys are still considered held from the last trial
+    while kb.getKeys(["m", "n"], waitRelease=False, clear=False):
+        core.wait(0.01)
+        kb.clearEvents()
+        event.clearEvents(eventType="keyboard")
+
     logger.debug("TRIG_VAS_ON (%s) code queued.", config.TRIG_VAS_ON.hex())
     continue_routine = True
 
@@ -408,6 +414,7 @@ for this_trial in main_loop:
         keys = kb.getKeys(
             ["m", "n", "space", "s", "escape"], waitRelease=False, clear=False
         )
+        keys = [k for k in keys if k.tDown >= vas_start_time]
 
         # Movement keys rely on the last event and require the key to still be held
         move_keys = [k for k in keys if k.name in ["m", "n"]]

--- a/main_experiment_sim.py
+++ b/main_experiment_sim.py
@@ -430,6 +430,12 @@ for this_trial in main_loop:
     kb.clearEvents()
     event.clearEvents(eventType="keyboard")
 
+    # Ensure no movement keys are still considered held from the last trial
+    while kb.getKeys(["m", "n"], waitRelease=False, clear=False):
+        core.wait(0.01)
+        kb.clearEvents()
+        event.clearEvents(eventType="keyboard")
+
     logger.debug("TRIG_VAS_ON (%s) code queued.", config.TRIG_VAS_ON.hex())
     continue_routine = True
 
@@ -456,6 +462,7 @@ for this_trial in main_loop:
         keys = kb.getKeys(
             ["m", "n", "space", "s", "escape"], waitRelease=False, clear=False
         )
+        keys = [k for k in keys if k.tDown >= vas_start_time]
 
         # Movement keys rely on the last event and require the key to still be held
         move_keys = [k for k in keys if k.name in ["m", "n"]]


### PR DESCRIPTION
## Summary
- ensure held M/N keys are released before the next VAS starts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856dfcd2d288331947bbdd8e39915d9