### PR TITLE
Fix runaway VAS cursor

### DIFF
--- a/main_experiment.py
+++ b/main_experiment.py
@@ -427,7 +427,11 @@ for this_trial in main_loop:
         if "s" in action_names:
             main_loop.finished = True
             continue_routine = False
-        if "space" in action_names:
+        confirm_pressed = "space" in action_names
+        move_held = any(
+            k.name in ["m", "n"] and k.duration is None for k in keys
+        )
+        if confirm_pressed and not move_held:
             continue_routine = False
 
         # Update marker position

--- a/main_experiment_sim.py
+++ b/main_experiment_sim.py
@@ -475,7 +475,11 @@ for this_trial in main_loop:
         if "s" in action_names:
             main_loop.finished = True
             continue_routine = False
-        if "space" in action_names:
+        confirm_pressed = "space" in action_names
+        move_held = any(
+            k.name in ["m", "n"] and k.duration is None for k in keys
+        )
+        if confirm_pressed and not move_held:
             continue_routine = False
 
         # Update marker position


### PR DESCRIPTION
## Summary
- revert previous attempt at ignoring held keys
- prevent pressing space while holding `m` or `n`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856dfcd2d288331947bbdd8e39915d9