### PR TITLE
Fix runaway VAS cursor

### DIFF
--- a/main_experiment.py
+++ b/main_experiment.py
@@ -384,6 +384,7 @@ for this_trial in main_loop:
 
     logger.debug("TRIG_VAS_ON (%s) code queued.", config.TRIG_VAS_ON.hex())
     continue_routine = True
+    waiting_for_release = False
 
     def trigger_vas_onset():
         if trigger_port and trigger_port.is_open:
@@ -427,7 +428,14 @@ for this_trial in main_loop:
         if "s" in action_names:
             main_loop.finished = True
             continue_routine = False
-        if "space" in action_names:
+
+        confirm_pressed = "space" in action_names
+        move_held = any(
+            k.name in ["m", "n"] and k.duration is None for k in keys
+        )
+        at_boundary = current_pos <= 0.0 or current_pos >= 100.0
+
+        if confirm_pressed and not (move_held and at_boundary):
             continue_routine = False
 
         # Update marker position
@@ -450,6 +458,12 @@ for this_trial in main_loop:
             last_sample_time = elapsed_time
 
         if elapsed_time >= config.VAS_MAX_DURATION_SECS:
+            if move_held and at_boundary:
+                waiting_for_release = True
+            else:
+                continue_routine = False
+
+        if waiting_for_release and not move_held:
             continue_routine = False
 
     # End Routine


### PR DESCRIPTION
## Summary
- prevent confirmation or timeout while movement key held at slider boundaries
- end as soon as key released if time already elapsed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856dfcd2d288331947bbdd8e39915d9