### PR TITLE
Fix VAS confirmation logic

### DIFF
--- a/main_experiment.py
+++ b/main_experiment.py
@@ -391,6 +391,7 @@ for this_trial in main_loop:
     logger.debug("TRIG_VAS_ON (%s) code queued.", config.TRIG_VAS_ON.hex())
     continue_routine = True
     waiting_for_release = False
+    held_moves = set()
 
     def trigger_vas_onset():
         if trigger_port and trigger_port.is_open:
@@ -461,7 +462,7 @@ for this_trial in main_loop:
         )
         at_boundary = current_pos <= 0.0 or current_pos >= 100.0
 
-        if confirm_pressed and not (move_held and at_boundary):
+        if confirm_pressed and not move_held:
             continue_routine = False
 
         # Update marker position

--- a/main_experiment_sim.py
+++ b/main_experiment_sim.py
@@ -483,7 +483,7 @@ for this_trial in main_loop:
         )
         at_boundary = current_pos <= 0.0 or current_pos >= 100.0
 
-        if confirm_pressed and not (move_held and at_boundary):
+        if confirm_pressed and not move_held:
             continue_routine = False
             
         # Update marker position


### PR DESCRIPTION
## Summary
- disallow confirming VAS rating while holding movement keys

## Testing
- `python -m py_compile main_experiment.py`
- `python -m py_compile main_experiment_sim.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68570c724f188331935b4f4e577f3bd2