### PR TITLE
Add global escape quit key

### DIFF
--- a/baseline_recording.py
+++ b/baseline_recording.py
@@ -8,6 +8,7 @@ import triggering
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+event.globalKeys.add(key="escape", func=core.quit)
 
 # -----------------------------------------------------------------
 # 1. Participant/Session Info


### PR DESCRIPTION
## Summary
- allow baseline recording to be aborted with the Escape key by registering a global key

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -r requirements.txt` *(fails: building wheel for wxPython)*

------
https://chatgpt.com/codex/tasks/task_e_6862d9a0e97483319a4341df29e47401