### PR TITLE
Remove beeps and save stim plots

### DIFF
--- a/hardware_setup.py
+++ b/hardware_setup.py
@@ -8,13 +8,25 @@ from psychopy.hardware import brainproducts
 # Import trigger definitions from your config file
 from config import TRIG_RESET
 
-def initialize_thermode(port_name, baseline_temp):
-    """Initialize the thermode device and set its baseline temperature."""
+def initialize_thermode(port_name, baseline_temp, beep=False):
+    """Initialize the thermode device and set its baseline temperature.
+
+    Parameters
+    ----------
+    port_name : str
+        Serial port to open.
+    baseline_temp : float
+        Baseline temperature in °C to apply on all surfaces.
+    beep : bool, optional
+        Whether to emit a beep on stimulation start. Defaults to ``False``.
+    """
     print(f"Initializing Thermode on {port_name}...")
     try:
-        thermode = tcsii_serial(port_name, beep=True)
+        thermode = tcsii_serial(port_name, beep=beep)
         thermode.set_baseline(baseline_temp)
-        print(f"SUCCESS: Thermode initialized on {port_name} with baseline {baseline_temp}°C.")
+        print(
+            f"SUCCESS: Thermode initialized on {port_name} with baseline {baseline_temp}°C."
+        )
         return thermode
     except Exception as e:
         print(f"FATAL ERROR: Thermode initialization failed on {port_name}: {e}")

--- a/main_experiment.py
+++ b/main_experiment.py
@@ -57,7 +57,9 @@ _thisDir = os.path.dirname(os.path.abspath(__file__))
 os.chdir(_thisDir)
 
 # --- Initialize Hardware ---
-thermode = hw.initialize_thermode(exp_info["com_thermode"], config.BASELINE_TEMP)
+thermode = hw.initialize_thermode(
+    exp_info["com_thermode"], config.BASELINE_TEMP, beep=False
+)
 trigger_port = hw.initialize_trigger_port(exp_info["com_trigger"])
 rcs = hw.initialize_eeg_rcs(
     host_ip=exp_info["eeg_ip"],

--- a/main_experiment_with_stimlog.py
+++ b/main_experiment_with_stimlog.py
@@ -56,8 +56,15 @@ exp_name = f"ThermalPainEEGFMRI_run{run_number}"
 _thisDir = os.path.dirname(os.path.abspath(__file__))
 os.chdir(_thisDir)
 
+# Directory for outputs
+participant_dir = os.path.join(_thisDir, "data", exp_info["participant"])
+os.makedirs(participant_dir, exist_ok=True)
+base_filename = f"{exp_info['participant']}_{exp_name}_{exp_info['date']}"
+
 # --- Initialize Hardware ---
-thermode = hw.initialize_thermode(exp_info["com_thermode"], config.BASELINE_TEMP)
+thermode = hw.initialize_thermode(
+    exp_info["com_thermode"], config.BASELINE_TEMP, beep=False
+)
 trigger_port = hw.initialize_trigger_port(exp_info["com_trigger"])
 rcs = hw.initialize_eeg_rcs(
     host_ip=exp_info["eeg_ip"],
@@ -292,13 +299,19 @@ for this_trial in main_loop:
                 linestyle=styles[idx],
             )
         plt.axhline(current_temp, label="target", linestyle="--", color="red")
-        plt.axhline(config.BASELINE_TEMP, label="baseline", linestyle="--", color="green")
+        plt.axhline(
+            config.BASELINE_TEMP, label="baseline", linestyle="--", color="green"
+        )
         plt.xlabel("Time (s)")
         plt.ylabel("Temperature (°C)")
         plt.legend()
         plt.tight_layout()
-        plt.show(block=False)
-        plt.pause(0.001)
+        plot_path = os.path.join(
+            participant_dir,
+            f"{base_filename}_trial{current_loop_index + 1}_TempPlot.png",
+        )
+        plt.savefig(plot_path)
+        plt.close(fig)
 
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#


### PR DESCRIPTION
## Summary
- allow `initialize_thermode` to disable beeping
- turn off thermode beep for main experiment variants
- create output directory and save stimulus plots instead of showing them

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68767583072c8331b526a35745ba50ed