### PR TITLE
Disallow VAS confirmation while moving cursor

### DIFF
--- a/main_experiment.py
+++ b/main_experiment.py
@@ -376,6 +376,7 @@ for this_trial in main_loop:
     vas_rating_trace, vas_time_trace = [], []
     current_pos = round(np.random.uniform(0, 100), 1)
     initial_pos = current_pos
+    prev_pos = current_pos
     interaction_occurred = False
     vas_timer = core.Clock()
     last_sample_time = 0.0
@@ -479,6 +480,8 @@ for this_trial in main_loop:
                 current_pos = max(0.0, current_pos - increment)
                 interaction_occurred = True
 
+        pos_changed = current_pos != prev_pos
+
         # Check for confirmation or abort actions
         action_names = {k.name for k in keys}
         if "escape" in action_names:
@@ -493,7 +496,7 @@ for this_trial in main_loop:
         )
         at_boundary = current_pos <= 0.0 or current_pos >= 100.0
 
-        if confirm_pressed and not move_held:
+        if confirm_pressed and not move_held and not pos_changed:
             continue_routine = False
 
         # Update marker position
@@ -524,6 +527,8 @@ for this_trial in main_loop:
 
         if waiting_for_release and not move_held:
             continue_routine = False
+
+        prev_pos = current_pos
 
     # End Routine
     final_rating_raw = current_pos

--- a/main_experiment_sim.py
+++ b/main_experiment_sim.py
@@ -422,6 +422,7 @@ for this_trial in main_loop:
     vas_rating_trace, vas_time_trace = [], []
     current_pos = round(np.random.uniform(0, 100), 1)
     initial_pos = current_pos
+    prev_pos = current_pos
     interaction_occurred = False
     vas_timer = core.Clock()
     last_sample_time = 0.0
@@ -497,6 +498,8 @@ for this_trial in main_loop:
             elif key == "2":
                 current_pos = max(0.0, current_pos - increment)
                 interaction_occurred = True
+
+        pos_changed = current_pos != prev_pos
                 
         # Check for confirmation or abort actions
         action_names = {k.name for k in keys}
@@ -512,7 +515,7 @@ for this_trial in main_loop:
         )
         at_boundary = current_pos <= 0.0 or current_pos >= 100.0
 
-        if confirm_pressed and not move_held:
+        if confirm_pressed and not move_held and not pos_changed:
             continue_routine = False
             
         # Update marker position
@@ -542,6 +545,8 @@ for this_trial in main_loop:
 
         if waiting_for_release and not move_held:
             continue_routine = False
+
+        prev_pos = current_pos
 
     # End Routine
     final_rating_raw = current_pos

--- a/main_experiment_with_stimlog.py
+++ b/main_experiment_with_stimlog.py
@@ -388,6 +388,7 @@ for this_trial in main_loop:
     vas_rating_trace, vas_time_trace = [], []
     current_pos = round(np.random.uniform(0, 100), 1)
     initial_pos = current_pos
+    prev_pos = current_pos
     interaction_occurred = False
     vas_timer = core.Clock()
     last_sample_time = 0.0
@@ -454,6 +455,8 @@ for this_trial in main_loop:
                 current_pos = max(0.0, current_pos - increment)
                 interaction_occurred = True
 
+        pos_changed = current_pos != prev_pos
+
         action_names = {k.name for k in keys}
         if "escape" in action_names:
             core.quit()
@@ -465,7 +468,7 @@ for this_trial in main_loop:
         move_held = any(k.name in ["3", "2"] and k.duration is None for k in keys)
         at_boundary = current_pos <= 0.0 or current_pos >= 100.0
 
-        if confirm_pressed and not move_held:
+        if confirm_pressed and not move_held and not pos_changed:
             continue_routine = False
 
         marker_x = -0.5 + (current_pos / 100.0)
@@ -492,6 +495,8 @@ for this_trial in main_loop:
 
         if waiting_for_release and not move_held:
             continue_routine = False
+
+        prev_pos = current_pos
 
     final_rating_raw = current_pos
     vas_rating_trace.append(final_rating_raw)


### PR DESCRIPTION
## Summary
- only accept VAS confirmation when the cursor remains still

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688039a2fcc48331b888dea94db1eb87