### PR TITLE
Configure VAS key mapping

### DIFF
--- a/config.py
+++ b/config.py
@@ -30,3 +30,7 @@ ITI_DURATION_RANGE = (15, 20) # Min and Max ITI in seconds
 VAS_SPEED_UNITS_PER_SEC = 22.0
 VAS_MAX_DURATION_SECS = 10.0
 VAS_SAMPLING_INTERVAL_SECS = 0.2
+
+# Key mapping for moving the VAS cursor
+VAS_LEFT_KEY = "2"
+VAS_RIGHT_KEY = "3"

--- a/main_experiment.py
+++ b/main_experiment.py
@@ -412,10 +412,13 @@ for this_trial in main_loop:
 
     # Start the VAS with a fresh keyboard instance so any held keys from the
     # previous trial cannot influence the slider at onset. If the participant is
-    # still physically holding '3' or '2' when the new scale appears, we ignore
-    # that key until it is released once.
+    # still physically holding the VAS movement keys when the new scale appears,
+    # we ignore that key until it is released once.
     kb = keyboard.Keyboard()
-    ignore_until_release = {k.name for k in kb.getKeys(["3", "2"], waitRelease=False)}
+    ignore_until_release = {
+        k.name
+        for k in kb.getKeys([config.VAS_RIGHT_KEY, config.VAS_LEFT_KEY], waitRelease=False)
+    }
     kb.clearEvents()
     event.clearEvents(eventType="keyboard")
 
@@ -423,6 +426,7 @@ for this_trial in main_loop:
     continue_routine = True
     waiting_for_release = False
     held_moves = set()
+    held_move_key = None
 
     def trigger_vas_onset():
         if trigger_port and trigger_port.is_open:
@@ -446,7 +450,15 @@ for this_trial in main_loop:
         # Collect all relevant key presses without clearing the buffer
 
         keys = kb.getKeys(
-            ["3", "2", "1", "s", "escape"], waitRelease=False, clear=False
+            [
+                config.VAS_RIGHT_KEY,
+                config.VAS_LEFT_KEY,
+                "1",
+                "s",
+                "escape",
+            ],
+            waitRelease=False,
+            clear=False,
         )
         keys = [k for k in keys if k.tDown >= vas_start_time]
 
@@ -462,22 +474,25 @@ for this_trial in main_loop:
 
         # Update held movement keys
         for k in keys:
-            if k.name in ["3", "2"]:
+            if k.name in [config.VAS_RIGHT_KEY, config.VAS_LEFT_KEY]:
                 if k.duration is None:
                     held_moves.add(k.name)
                 else:
                     held_moves.discard(k.name)
 
-        # Movement keys rely on the last event and require the key to still be held
-        move_keys = [k for k in keys if k.name in ["3", "2"]]
-        if move_keys and move_keys[-1].duration is None:
-            key = move_keys[-1].name
-            if key == "3":
-                current_pos = min(100.0, current_pos + increment)
-                interaction_occurred = True
-            elif key == "2":
-                current_pos = max(0.0, current_pos - increment)
-                interaction_occurred = True
+        # Ensure only one movement key is active at a time
+        if held_move_key not in held_moves:
+            held_move_key = None
+        if held_move_key is None and len(held_moves) == 1:
+            held_move_key = next(iter(held_moves))
+
+        # Move cursor based on the single active key
+        if held_move_key == config.VAS_RIGHT_KEY:
+            current_pos = min(100.0, current_pos + increment)
+            interaction_occurred = True
+        elif held_move_key == config.VAS_LEFT_KEY:
+            current_pos = max(0.0, current_pos - increment)
+            interaction_occurred = True
 
         # Check for confirmation or abort actions
         action_names = {k.name for k in keys}
@@ -488,9 +503,7 @@ for this_trial in main_loop:
             continue_routine = False
 
         confirm_pressed = "1" in action_names
-        move_held = any(
-            k.name in ["3", "2"] and k.duration is None for k in keys
-        )
+        move_held = held_move_key is not None
         at_boundary = current_pos <= 0.0 or current_pos >= 100.0
 
         if confirm_pressed and not move_held:

--- a/main_experiment_with_stimlog.py
+++ b/main_experiment_with_stimlog.py
@@ -438,21 +438,45 @@ for this_trial in main_loop:
 
     continue_routine = True
     waiting_for_release = False
+    held_moves = set()
+    held_move_key = None
 
     while continue_routine:
         increment = config.VAS_SPEED_UNITS_PER_SEC * frame_dur
 
-        keys = kb.getKeys(["3", "2", "1", "s", "escape"], waitRelease=False, clear=False)
+        keys = kb.getKeys(
+            [
+                config.VAS_RIGHT_KEY,
+                config.VAS_LEFT_KEY,
+                "1",
+                "s",
+                "escape",
+            ],
+            waitRelease=False,
+            clear=False,
+        )
 
-        move_keys = [k for k in keys if k.name in ["3", "2"]]
-        if move_keys and move_keys[-1].duration is None:
-            key = move_keys[-1].name
-            if key == "3":
-                current_pos = min(100.0, current_pos + increment)
-                interaction_occurred = True
-            elif key == "2":
-                current_pos = max(0.0, current_pos - increment)
-                interaction_occurred = True
+        # Update held movement keys
+        for k in keys:
+            if k.name in [config.VAS_RIGHT_KEY, config.VAS_LEFT_KEY]:
+                if k.duration is None:
+                    held_moves.add(k.name)
+                else:
+                    held_moves.discard(k.name)
+
+        # Ensure only one movement key is active at a time
+        if held_move_key not in held_moves:
+            held_move_key = None
+        if held_move_key is None and len(held_moves) == 1:
+            held_move_key = next(iter(held_moves))
+
+        # Move cursor based on the single active key
+        if held_move_key == config.VAS_RIGHT_KEY:
+            current_pos = min(100.0, current_pos + increment)
+            interaction_occurred = True
+        elif held_move_key == config.VAS_LEFT_KEY:
+            current_pos = max(0.0, current_pos - increment)
+            interaction_occurred = True
 
         action_names = {k.name for k in keys}
         if "escape" in action_names:
@@ -462,7 +486,7 @@ for this_trial in main_loop:
             continue_routine = False
 
         confirm_pressed = "1" in action_names
-        move_held = any(k.name in ["3", "2"] and k.duration is None for k in keys)
+        move_held = held_move_key is not None
         at_boundary = current_pos <= 0.0 or current_pos >= 100.0
 
         if confirm_pressed and not move_held:


### PR DESCRIPTION
## Summary
- allow configuring keys that move the VAS cursor
- use the constants in all experiment scripts
- ensure only a single movement key can be held at any time

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68804bac15048331a39567948ba52bb1